### PR TITLE
Basic configuration file parser

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,6 @@
+CompileFlags:
+  Add:
+    - "-xc++"
+    - "-I../include"
+    - "-I../../include"
+    - "-std=c++98"

--- a/.gitignore
+++ b/.gitignore
@@ -2,29 +2,8 @@
 *.d
 
 # Compiled Object files
-*.slo
-*.lo
 *.o
 *.obj
-
-# Precompiled Headers
-*.gch
-*.pch
-
-# Compiled Dynamic libraries
-*.so
-*.dylib
-*.dll
-
-# Fortran module files
-*.mod
-*.smod
-
-# Compiled Static libraries
-*.lai
-*.la
-*.a
-*.lib
 
 # Executables
 *.exe

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,7 @@
 *.exe
 *.out
 *.app
-webserv
+/webserv
+
+# Misc
+webserv.conf

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CXXFLAGS := -Werror
 CXXFLAGS += -std=c++98
 CXXFLAGS += -Iinclude
 
-MODULES := worker
+MODULES := worker config
 OBJ_DIR := .obj
 SRC_DIR := src
 
@@ -26,8 +26,7 @@ DEPS := $(patsubst %.o,%.d,$(OBJS))
 NAME := webserv
 
 .PHONY: all
-all:
-	$(MAKE) $(NAME)
+all: $(NAME)
 
 $(NAME): $(OBJS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ $(OBJS)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CXXFLAGS := -Werror
 CXXFLAGS += -std=c++98
 CXXFLAGS += -Iinclude
 
-MODULES := worker config
+MODULES := config
 OBJ_DIR := .obj
 SRC_DIR := src
 

--- a/Makefile
+++ b/Makefile
@@ -1,35 +1,51 @@
-NAME := webserv
+MAKEFLAGS := --no-print-directory
 
+Q := @
+
+RM := rm -fv
 CXX := c++
-CPPFLAGS := -MMD -MP
-CXXFLAGS := -Wall -Wextra -Werror -std=c++98
 
+CPPFLAGS := -MMD -MP
+CXXFLAGS := -Wall -Wextra
+CXXFLAGS := -Werror
+CXXFLAGS += -std=c++98
+CXXFLAGS += -Iinclude
+
+MODULES := worker
+OBJ_DIR := .obj
 SRC_DIR := src
-SRCS := main.cpp
-OBJ_DIR := .build
-OBJS := $(patsubst %,$(OBJ_DIR)/%.o,$(SRCS))
+
+SRCS :=
+SRCS += main.cpp
+
+include $(patsubst %,$(SRC_DIR)/%/.srcs.mk,$(MODULES))
+
+OBJS := $(patsubst %.cpp,$(OBJ_DIR)/%.o,$(SRCS))
 DEPS := $(patsubst %.o,%.d,$(OBJS))
 
+NAME := webserv
+
 .PHONY: all
-all: $(NAME)
+all:
+	$(MAKE) $(NAME)
 
 $(NAME): $(OBJS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ $(OBJS)
 
-$(OBJ_DIR)/%.o: $(SRC_DIR)/%
-	@mkdir -p $(dir $@)
+$(OBJ_DIR)/%.o:: $(SRC_DIR)/%.cpp
+	$(Q)mkdir -p $(dir $@)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ -c $<
 
 .PHONY: clean
 clean:
-	$(RM) -r $(OBJ_DIR)
+	$(Q)$(RM) -r $(OBJ_DIR)
 
 .PHONY: fclean
 fclean: clean
-	$(RM) $(NAME)
+	$(Q)$(RM) $(NAME)
 
 .PHONY: re
 re: fclean
-	@$(MAKE) --no-print-directory $(NAME)
+	$(Q)$(MAKE) $(NAME)
 
 -include $(DEPS)

--- a/include/webserv/Config.hpp
+++ b/include/webserv/Config.hpp
@@ -1,0 +1,81 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   Config.hpp                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ll-hotel <ll-hotel@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/11 21:00:43 by ll-hotel          #+#    #+#             */
+/*   Updated: 2024/12/15 22:03:39 by ll-hotel         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef WEBSERV_CONFIG_HPP
+#define WEBSERV_CONFIG_HPP
+#include "webserv/Exception.hpp"
+#include "webserv/parsing.hpp"
+#include <map>
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+class Config {
+public:
+	class Server {
+	private:
+		uint16_t _port;
+		std::string _host;
+		std::vector<std::string> _server_names;
+		// TODO: ERROR PAGES
+		// error_page 404 ./404_page.html
+		// TODO: ROUTES
+		// class RedirectionRoute {
+		// public:
+		// 	std::vector<std::string> route_methods;
+		// 	std::string redirection_url;
+		// 	std::string root_dir;
+		// 	bool do_directory_listing;
+		// 	std::string default_dir_file;
+		// 	// TODO: CGI
+		// 	// std::string cgi_extensions;
+		// 	std::string http_methods;
+		// 	bool do_file_upload;
+		// 	std::string file_save_dir;
+		// };
+		// std::vector<RedirectionRoute> routes;
+		void __use_token(ConfigToken::Vector::const_iterator &tok);
+
+	public:
+		Server();
+		Server(ConfigToken::Vector::const_iterator &it);
+                Server& operator=(const Server &other) throw();
+
+		uint16_t port() const;
+		const std::string& host() const;
+		const std::vector<std::string>& server_names() const;
+	};
+
+private:
+	std::vector<Server> _servers;
+	std::map<uint16_t, std::string> _error_pages;
+	size_t _max_client_body_size;
+
+public:
+	Config() throw();
+	Config(const std::string &file_path);
+	Config(const Config&) throw();
+	Config& operator=(const Config&) throw();
+	~Config() throw();
+
+	const std::vector<Server>& getServerConfigs();
+	const std::map<uint16_t, std::string>& getErrorPages();
+	size_t getMaxClientBodySize();
+
+	class FileErrorException : public WebservException {
+		FileErrorException(const std::string &str):
+			WebservException(str)
+		{}
+	};
+};
+
+#endif

--- a/include/webserv/Config.hpp
+++ b/include/webserv/Config.hpp
@@ -6,7 +6,7 @@
 /*   By: ll-hotel <ll-hotel@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/11 21:00:43 by ll-hotel          #+#    #+#             */
-/*   Updated: 2024/12/15 22:03:39 by ll-hotel         ###   ########.fr       */
+/*   Updated: 2024/12/16 05:28:14 by ll-hotel         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,9 +50,9 @@ public:
 		Server(ConfigToken::Vector::const_iterator &it);
                 Server& operator=(const Server &other) throw();
 
-		uint16_t port() const;
-		const std::string& host() const;
-		const std::vector<std::string>& server_names() const;
+		uint16_t getPort() const;
+		const std::string& getHost() const;
+		const std::vector<std::string>& getServerNames() const;
 	};
 
 private:
@@ -67,7 +67,7 @@ public:
 	Config& operator=(const Config&) throw();
 	~Config() throw();
 
-	const std::vector<Server>& getServerConfigs();
+	const std::vector<Server>& getServers();
 	const std::map<uint16_t, std::string>& getErrorPages();
 	size_t getMaxClientBodySize();
 

--- a/include/webserv/Exception.hpp
+++ b/include/webserv/Exception.hpp
@@ -1,0 +1,38 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   Exception.hpp                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ll-hotel <ll-hotel@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/11 21:00:43 by ll-hotel          #+#    #+#             */
+/*   Updated: 2024/12/11 22:00:45 by ll-hotel         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef WEBSERV_EXCEPTION_HPP
+#define WEBSERV_EXCEPTION_HPP
+#include <exception>
+#include <iostream>
+#include <string>
+
+class WebservException : public std::exception {
+private:
+	const std::string _str;
+public:
+	WebservException(const std::string &str):
+		_str("webserv: exception: " + str)
+	{}
+	virtual ~WebservException() throw()
+	{};
+	virtual const char *what() const throw()
+	{
+		return _str.c_str();
+	}
+	virtual void print() const throw()
+	{
+		std::cerr << what() << std::endl;
+	}
+};
+
+#endif

--- a/include/webserv/Exception.hpp
+++ b/include/webserv/Exception.hpp
@@ -6,7 +6,7 @@
 /*   By: ll-hotel <ll-hotel@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/11 21:00:43 by ll-hotel          #+#    #+#             */
-/*   Updated: 2024/12/11 22:00:45 by ll-hotel         ###   ########.fr       */
+/*   Updated: 2024/12/15 22:08:39 by ll-hotel         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,13 +15,14 @@
 #include <exception>
 #include <iostream>
 #include <string>
+#define WS_THROW(error) throw(WebservException(error))
 
 class WebservException : public std::exception {
 private:
 	const std::string _str;
 public:
 	WebservException(const std::string &str):
-		_str("webserv: exception: " + str)
+		_str("webserv: error: " + str)
 	{}
 	virtual ~WebservException() throw()
 	{};

--- a/include/webserv/parsing.hpp
+++ b/include/webserv/parsing.hpp
@@ -6,7 +6,7 @@
 /*   By: ll-hotel <ll-hotel@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/12 18:46:18 by ll-hotel          #+#    #+#             */
-/*   Updated: 2024/12/15 20:46:25 by ll-hotel         ###   ########.fr       */
+/*   Updated: 2024/12/16 05:30:53 by ll-hotel         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,8 +51,8 @@ class Token {
 		~Token() throw()
 		{};
 
-		const_typeref type() const throw() { return _type; }
-		const_valueref value() const throw() { return _value; }
+		const_typeref getType() const throw() { return _type; }
+		const_valueref getValue() const throw() { return _value; }
 };
 
 enum LexerType {

--- a/include/webserv/parsing.hpp
+++ b/include/webserv/parsing.hpp
@@ -1,0 +1,70 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parsing.hpp                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ll-hotel <ll-hotel@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/12 18:46:18 by ll-hotel          #+#    #+#             */
+/*   Updated: 2024/12/15 20:46:25 by ll-hotel         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef WEBSERV_PARSING_HPP
+#define WEBSERV_PARSING_HPP
+#include <list>
+#include <vector>
+#include <string>
+
+template <typename TokenType, typename TokenValue>
+class Token {
+	private:
+		TokenType _type;
+		TokenValue _value;
+
+	public:
+		typedef std::list< Token<TokenType, TokenValue> >List;
+		typedef std::vector< Token<TokenType, TokenValue> >Vector;
+		typedef TokenType type_type;
+		typedef TokenValue value_type;
+		typedef const TokenType& const_typeref;
+		typedef const TokenValue& const_valueref;
+
+		Token()
+		{};
+		Token(const TokenType &type, const TokenValue &value)
+		{
+			_type = type;
+			_value = value;
+		};
+		Token(const Token<TokenType, TokenValue> &other)
+		{
+			_type = other._type;
+			_value = other._value;
+		};
+		Token& operator=(const Token<TokenType, TokenValue> &other)
+		{
+			_type = other._type;
+			_value = other._value;
+			return *this;
+		};
+		~Token() throw()
+		{};
+
+		const_typeref type() const throw() { return _type; }
+		const_valueref value() const throw() { return _value; }
+};
+
+enum LexerType {
+	WORD,
+	BLOCK_START,
+	BLOCK_END,
+	ARG_END,
+};
+
+typedef Token<LexerType, std::string> ConfigToken;
+
+#define THROW_UNEXPECTED(value) \
+	throw(WebservException("unexpected token '" + (value) + "'"))
+
+#endif

--- a/src/config/.srcs.mk
+++ b/src/config/.srcs.mk
@@ -1,0 +1,1 @@
+SRCS += config/Config.cpp config/lexer.cpp config/read_file.cpp config/Config_Server.cpp

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -1,0 +1,69 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   Config.cpp                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ll-hotel <ll-hotel@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/11 21:21:15 by ll-hotel          #+#    #+#             */
+/*   Updated: 2024/12/15 22:07:31 by ll-hotel         ###   ########.fr       */
+/* ************************************************************************** */
+
+#include "webserv/Config.hpp"
+#include "webserv/parsing.hpp"
+#include <cctype>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+extern std::string read_file(const std::string &file_path);
+extern ConfigToken::Vector lexer(const std::string &content);
+extern ConfigToken parser(ConfigToken::List::const_iterator block_start);
+
+Config::Config() throw()
+{
+}
+
+Config::Config(const std::string &file_path)
+{
+	const std::string content = read_file(file_path);
+	const ConfigToken::Vector tokens = lexer(content);
+	ConfigToken::Vector::const_iterator it;
+
+	for (it = tokens.begin(); it != tokens.end(); ++it)
+		_servers.push_back(Config::Server(it));
+}
+
+Config::Config(const Config &config) throw()
+{
+	*this = config;
+}
+
+Config& Config::operator=(const Config &other) throw()
+{
+	_servers = other._servers;
+	_error_pages = other._error_pages;
+	_max_client_body_size = other._max_client_body_size;
+	return *this;
+}
+
+Config::~Config() throw()
+{
+}
+
+const std::vector<Config::Server>& Config::getServerConfigs()
+{
+	return _servers;
+}
+
+const std::map<uint16_t, std::string>& Config::getErrorPages()
+{
+	return _error_pages;
+}
+
+size_t Config::getMaxClientBodySize()
+{
+	return _max_client_body_size;
+}

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -6,7 +6,7 @@
 /*   By: ll-hotel <ll-hotel@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/11 21:21:15 by ll-hotel          #+#    #+#             */
-/*   Updated: 2024/12/16 02:41:42 by ll-hotel         ###   ########.fr       */
+/*   Updated: 2024/12/16 05:29:51 by ll-hotel         ###   ########.fr       */
 /* ************************************************************************** */
 
 #include "webserv/Config.hpp"
@@ -52,7 +52,7 @@ Config::~Config() throw()
 {
 }
 
-const std::vector<Config::Server>& Config::getServerConfigs()
+const std::vector<Config::Server>& Config::getServers()
 {
 	return _servers;
 }

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -6,7 +6,7 @@
 /*   By: ll-hotel <ll-hotel@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/11 21:21:15 by ll-hotel          #+#    #+#             */
-/*   Updated: 2024/12/15 22:07:31 by ll-hotel         ###   ########.fr       */
+/*   Updated: 2024/12/16 02:41:42 by ll-hotel         ###   ########.fr       */
 /* ************************************************************************** */
 
 #include "webserv/Config.hpp"
@@ -20,7 +20,6 @@
 
 extern std::string read_file(const std::string &file_path);
 extern ConfigToken::Vector lexer(const std::string &content);
-extern ConfigToken parser(ConfigToken::List::const_iterator block_start);
 
 Config::Config() throw()
 {

--- a/src/config/Config_Server.cpp
+++ b/src/config/Config_Server.cpp
@@ -6,7 +6,7 @@
 /*   By: ll-hotel <ll-hotel@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/14 13:14:03 by ll-hotel          #+#    #+#             */
-/*   Updated: 2024/12/15 22:04:27 by ll-hotel         ###   ########.fr       */
+/*   Updated: 2024/12/16 05:33:24 by ll-hotel         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,30 +35,30 @@ Config::Server::Server()
 
 void Config::Server::__use_token(ConfigToken::Vector::const_iterator &tok)
 {
-	const std::string var = tok->value();
+	const std::string var = tok->getValue();
 
-	if (tok->type() == BLOCK_END)
+	if (tok->getType() == BLOCK_END)
 		return;
 	++tok;
-	if (tok->type() != WORD)
+	if (tok->getType() != WORD)
 		throw(WebservException("missing value for " + var));
 	if (var == "host") {
-		_host = tok->value();
+		_host = tok->getValue();
 		++tok;
 	} else if (var == "port") {
-		if (!is_port(tok->value()))
+		if (!is_port(tok->getValue()))
 			throw(WebservException("expected uint value for port"));
-		_port = std::atoi(tok->value().c_str());
+		_port = std::atoi(tok->getValue().c_str());
 		++tok;
 	} else if (var == "server_name") {
-		while (tok->type() == WORD) {
-			_server_names.push_back(tok->value());
+		while (tok->getType() == WORD) {
+			_server_names.push_back(tok->getValue());
 			++tok;
 		}
 	} else {
 		return;
 	}
-	if (tok->type() != ARG_END)
+	if (tok->getType() != ARG_END)
 		throw(WebservException("too many values for " + var));
 }
 
@@ -66,15 +66,15 @@ Config::Server::Server(ConfigToken::Vector::const_iterator &tok)
 {
 	*this = Server();
 
-	if (tok->value() != "server")
-		THROW_UNEXPECTED(tok->value());
+	if (tok->getValue() != "server")
+		THROW_UNEXPECTED(tok->getValue());
 	++tok;
-	if (tok->type() != BLOCK_START)
-		THROW_UNEXPECTED(tok->value());
+	if (tok->getType() != BLOCK_START)
+		THROW_UNEXPECTED(tok->getValue());
 	do {
 		++tok;
 		__use_token(tok);
-	} while (tok->type() != BLOCK_END);
+	} while (tok->getType() != BLOCK_END);
 }
 
 Config::Server& Config::Server::operator=(const Server &other) throw()
@@ -85,17 +85,17 @@ Config::Server& Config::Server::operator=(const Server &other) throw()
 	return *this;
 }
 
-const std::string& Config::Server::host() const
+const std::string& Config::Server::getHost() const
 {
 	return _host;
 }
 
-uint16_t Config::Server::port() const
+uint16_t Config::Server::getPort() const
 {
 	return _port;
 }
 
-const std::vector<std::string>& Config::Server::server_names() const
+const std::vector<std::string>& Config::Server::getServerNames() const
 {
 	return _server_names;
 }

--- a/src/config/Config_Server.cpp
+++ b/src/config/Config_Server.cpp
@@ -1,0 +1,101 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   Config_Server.cpp                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ll-hotel <ll-hotel@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/14 13:14:03 by ll-hotel          #+#    #+#             */
+/*   Updated: 2024/12/15 22:04:27 by ll-hotel         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <string>
+#include <cstdlib>
+#include "webserv/parsing.hpp"
+#include "webserv/Config.hpp"
+
+static bool is_port(const std::string &str)
+{
+	if (str.empty())
+		return false;
+	for (size_t i = 0; i < str.size(); i += 1) {
+		if (!std::isdigit(str[i]))
+			return false;
+	}
+	return true;
+}
+
+Config::Server::Server()
+{
+	_host = "localhost";
+	_port = 80;
+	_server_names.clear();
+}
+
+void Config::Server::__use_token(ConfigToken::Vector::const_iterator &tok)
+{
+	const std::string var = tok->value();
+
+	if (tok->type() == BLOCK_END)
+		return;
+	++tok;
+	if (tok->type() != WORD)
+		throw(WebservException("missing value for " + var));
+	if (var == "host") {
+		_host = tok->value();
+		++tok;
+	} else if (var == "port") {
+		if (!is_port(tok->value()))
+			throw(WebservException("expected uint value for port"));
+		_port = std::atoi(tok->value().c_str());
+		++tok;
+	} else if (var == "server_name") {
+		while (tok->type() == WORD) {
+			_server_names.push_back(tok->value());
+			++tok;
+		}
+	} else {
+		return;
+	}
+	if (tok->type() != ARG_END)
+		throw(WebservException("too many values for " + var));
+}
+
+Config::Server::Server(ConfigToken::Vector::const_iterator &tok)
+{
+	*this = Server();
+
+	if (tok->value() != "server")
+		THROW_UNEXPECTED(tok->value());
+	++tok;
+	if (tok->type() != BLOCK_START)
+		THROW_UNEXPECTED(tok->value());
+	do {
+		++tok;
+		__use_token(tok);
+	} while (tok->type() != BLOCK_END);
+}
+
+Config::Server& Config::Server::operator=(const Server &other) throw()
+{
+	_port = other._port;
+	_host = other._host;
+	_server_names = other._server_names;
+	return *this;
+}
+
+const std::string& Config::Server::host() const
+{
+	return _host;
+}
+
+uint16_t Config::Server::port() const
+{
+	return _port;
+}
+
+const std::vector<std::string>& Config::Server::server_names() const
+{
+	return _server_names;
+}

--- a/src/config/lexer.cpp
+++ b/src/config/lexer.cpp
@@ -1,0 +1,128 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   lexer.cpp                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ll-hotel <ll-hotel@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/14 13:04:23 by ll-hotel          #+#    #+#             */
+/*   Updated: 2024/12/15 22:06:23 by ll-hotel         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "webserv/Exception.hpp"
+#include "webserv/parsing.hpp"
+#include <string>
+
+static void token_checker(const ConfigToken::Vector &tokens);
+static std::string itos(int n);
+static bool isseparator(char c) throw();
+
+ConfigToken::Vector lexer(const std::string &content)
+{
+	ConfigToken::Vector tokens;
+	int line;
+	size_t i;
+	size_t w;
+
+	line = 0;
+	i = 0;
+	for (i = 0; i < content.length(); i += 1) {
+		const char c = content[i];
+
+		if (!isseparator(c)) {
+			w = i;
+			while (i < content.length() && !isseparator(content[i]))
+				i += 1;
+			const std::string word(content.substr(w, i - w));
+			i -= 1;
+			tokens.push_back(ConfigToken(WORD, word));
+		} else if (!std::isspace(c)) {
+			ConfigToken::type_type token_type;
+			ConfigToken::value_type token_value;
+
+			switch (c) {
+			case '{':
+				token_type = BLOCK_START;
+				token_value = "{";
+				break;
+			case '}':
+				token_type = BLOCK_END;
+				token_value = "}";
+				break;
+			case ';':
+				token_type = ARG_END;
+				token_value = ";";
+				break;
+			default:
+				throw(WebservException("unexpected character "
+					"'" + std::string((char []){c, '\0'}) +
+					"' at line " + itos(line)));
+			}
+			tokens.push_back(ConfigToken(token_type, token_value));
+		}
+		if (c == '\n')
+			line += 1;
+	}
+	token_checker(tokens);
+	return tokens;
+}
+
+static void increment_i(const ConfigToken &tok, size_t &i, const size_t l) {
+	i += 1;
+	if (i >= l && tok.type() != BLOCK_END) {
+		std::string err = "missing ";
+		if (tok.type() == BLOCK_START || tok.type() == ARG_END)
+			err += "'}'";
+		else
+			err += "value after token " + tok.value();
+		throw(WebservException(err));
+	}
+}
+
+static void token_checker(const ConfigToken::Vector &tokens)
+{
+	const size_t limit = tokens.size();
+	size_t i = 0;
+
+	while (i < limit) {
+		if (tokens[i].value() != "server")
+			THROW_UNEXPECTED(tokens[i].value());
+		increment_i(tokens[i], i, limit);
+		if (tokens[i].type() != BLOCK_START)
+			THROW_UNEXPECTED(tokens[i].value());
+		increment_i(tokens[i], i, limit);
+		while (tokens[i].type() != BLOCK_END) {
+			do {
+				if (tokens[i].type() != WORD)
+					THROW_UNEXPECTED(tokens[i].value());
+				increment_i(tokens[i], i, limit);
+			} while (tokens[i].type() != ARG_END);
+			increment_i(tokens[i], i, limit);
+		}
+		increment_i(tokens[i], i, limit);
+        }
+}
+
+static std::string itos(int n)
+{
+	const bool negative = n < 0;
+	char buf[15] = {0};
+	size_t i;
+
+	i = 15;
+	do {
+		buf[--i] = (n % 10) + '0';
+		n /= 10;
+	} while (n != 0);
+	if (negative)
+		buf[--i] = '-';
+	return std::string(&buf[i]);
+}
+
+static bool isseparator(char c) throw()
+{
+	static const std::string separators = "{};";
+
+	return std::isspace(c) || separators.find(c) != std::string::npos;
+}

--- a/src/config/lexer.cpp
+++ b/src/config/lexer.cpp
@@ -6,7 +6,7 @@
 /*   By: ll-hotel <ll-hotel@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/14 13:04:23 by ll-hotel          #+#    #+#             */
-/*   Updated: 2024/12/15 22:06:23 by ll-hotel         ###   ########.fr       */
+/*   Updated: 2024/12/16 05:37:37 by ll-hotel         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,12 +70,12 @@ ConfigToken::Vector lexer(const std::string &content)
 
 static void increment_i(const ConfigToken &tok, size_t &i, const size_t l) {
 	i += 1;
-	if (i >= l && tok.type() != BLOCK_END) {
+	if (i >= l && tok.getType() != BLOCK_END) {
 		std::string err = "missing ";
-		if (tok.type() == BLOCK_START || tok.type() == ARG_END)
+		if (tok.getType() == BLOCK_START || tok.getType() == ARG_END)
 			err += "'}'";
 		else
-			err += "value after token " + tok.value();
+			err += "value after token " + tok.getValue();
 		throw(WebservException(err));
 	}
 }
@@ -86,18 +86,18 @@ static void token_checker(const ConfigToken::Vector &tokens)
 	size_t i = 0;
 
 	while (i < limit) {
-		if (tokens[i].value() != "server")
-			THROW_UNEXPECTED(tokens[i].value());
+		if (tokens[i].getValue() != "server")
+			THROW_UNEXPECTED(tokens[i].getValue());
 		increment_i(tokens[i], i, limit);
-		if (tokens[i].type() != BLOCK_START)
-			THROW_UNEXPECTED(tokens[i].value());
+		if (tokens[i].getType() != BLOCK_START)
+			THROW_UNEXPECTED(tokens[i].getValue());
 		increment_i(tokens[i], i, limit);
-		while (tokens[i].type() != BLOCK_END) {
+		while (tokens[i].getType() != BLOCK_END) {
 			do {
-				if (tokens[i].type() != WORD)
-					THROW_UNEXPECTED(tokens[i].value());
+				if (tokens[i].getType() != WORD)
+					THROW_UNEXPECTED(tokens[i].getValue());
 				increment_i(tokens[i], i, limit);
-			} while (tokens[i].type() != ARG_END);
+			} while (tokens[i].getType() != ARG_END);
 			increment_i(tokens[i], i, limit);
 		}
 		increment_i(tokens[i], i, limit);

--- a/src/config/read_file.cpp
+++ b/src/config/read_file.cpp
@@ -1,0 +1,31 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   read_file.cpp                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ll-hotel <ll-hotel@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/14 13:00:58 by ll-hotel          #+#    #+#             */
+/*   Updated: 2024/12/15 22:10:15 by ll-hotel         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "webserv/Exception.hpp"
+#include <fstream>
+#include <string>
+#include <cstring>
+
+std::string read_file(const std::string &file_path)
+{
+	std::string content;
+	std::ifstream file_stream(file_path.c_str());
+
+	if (!file_stream.is_open()) {
+		content = "can not open " + file_path;
+		content += std::string(": ") + std::strerror(errno);
+		WS_THROW(content);
+	}
+	std::getline(file_stream, content, '\0');
+	file_stream.close();
+	return content;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,43 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   main.cpp                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: gcros <gcros@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/03 18:40:52 by gcros             #+#    #+#             */
+/*   Updated: 2024/12/16 05:12:02 by ll-hotel         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "webserv/Config.hpp"
+#include "webserv/Exception.hpp"
+#include <iostream>
+#include <vector>
+
 int main(void)
 {
+	Config conf;
+
+	try {
+		conf = Config("webserv.conf");
+	} catch (WebservException &e) {
+		e.print();
+		return 1;
+	}
+
+	std::cout << "Configuration:\n\n";
+	for (size_t i = 0; i < conf.getServerConfigs().size(); i += 1) {
+		const Config::Server &srv = conf.getServerConfigs()[i];
+
+		if (srv.server_names().size() == 0)
+			std::cout << "<anonymous server> ";
+		for (size_t i = 0; i < srv.server_names().size(); i += 1)
+			std::cout << srv.server_names()[i] << ' ';
+		std::cout << "{";
+		std::cout << "\n\thost: " << srv.host();
+		std::cout << "\n\tport: " << srv.port();
+		std::cout << "\n}" << std::endl;
+	}
 	return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 /*   By: gcros <gcros@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/03 18:40:52 by gcros             #+#    #+#             */
-/*   Updated: 2024/12/16 05:12:02 by ll-hotel         ###   ########.fr       */
+/*   Updated: 2024/12/16 05:33:58 by ll-hotel         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,16 +27,16 @@ int main(void)
 	}
 
 	std::cout << "Configuration:\n\n";
-	for (size_t i = 0; i < conf.getServerConfigs().size(); i += 1) {
-		const Config::Server &srv = conf.getServerConfigs()[i];
+	for (size_t i = 0; i < conf.getServers().size(); i += 1) {
+		const Config::Server &srv = conf.getServers()[i];
 
-		if (srv.server_names().size() == 0)
+		if (srv.getServerNames().size() == 0)
 			std::cout << "<anonymous server> ";
-		for (size_t i = 0; i < srv.server_names().size(); i += 1)
-			std::cout << srv.server_names()[i] << ' ';
+		for (size_t i = 0; i < srv.getServerNames().size(); i += 1)
+			std::cout << srv.getServerNames()[i] << ' ';
 		std::cout << "{";
-		std::cout << "\n\thost: " << srv.host();
-		std::cout << "\n\tport: " << srv.port();
+		std::cout << "\n\thost: " << srv.getHost();
+		std::cout << "\n\tport: " << srv.getPort();
 		std::cout << "\n}" << std::endl;
 	}
 	return 0;

--- a/src/worker/.srcs.mk
+++ b/src/worker/.srcs.mk
@@ -1,0 +1,3 @@
+srcs := Client.cpp Socket.cpp Worker.cpp WorkerEntry.cpp
+
+SRCS += $(addprefix worker/,$(srcs))

--- a/src/worker/.srcs.mk
+++ b/src/worker/.srcs.mk
@@ -1,3 +1,0 @@
-srcs := Client.cpp Socket.cpp Worker.cpp WorkerEntry.cpp
-
-SRCS += $(addprefix worker/,$(srcs))


### PR DESCRIPTION
Created a configuration file parser, which give power to modify the following server parameters:
- host: the ip address to use as host.
- port: the port to listen requests to.
- server_name: the server name(s).

The configuration file syntax resembles NGINX's one:
```
server {
    host localhost;
    port 80;
    server_name webserv;
}
```
but you can use as many whitespaces as you want!